### PR TITLE
feat: add zellij assistant aliases

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -44,6 +44,8 @@ __uv_completion_patch
 # alias
 alias codex='codex --search'
 alias wb='workbloom'
+alias myassistant='zellij a myassistant'
+alias myassistant-codex='zellij a myassistant-codex'
 
 alias grp='cd $(ghq root)/$(ghq list | peco)'
 alias pcd='cd $(dirname $(find . | peco))'


### PR DESCRIPTION
## 概要
- `.zshrc` に `myassistant` alias を追加
- `.zshrc` に `myassistant-codex` alias を追加
- zellij の既存セッションへ短いコマンドで attach できるようにする

## 変更理由
- `zellij a myassistant` と `zellij a myassistant-codex` を毎回手入力せずに呼べるようにするため

## 確認内容
- `zsh -n .zshrc`
- `rg -n "alias myassistant|alias myassistant-codex" .zshrc`